### PR TITLE
Ignore table cell children with no text

### DIFF
--- a/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
+++ b/prettyprinter/textractprettyprinter/t_pretty_print_layout.py
@@ -128,7 +128,11 @@ class LinearizeLayout:
                             for cell_id in cell_rel['Ids']:
                                 cell_block = id2block[cell_id]
                                 if "Relationships" in cell_block:
-                                    cell_text = " ".join([id2block[line_id]['Text'] for line_id in cell_block["Relationships"][0]['Ids']])
+                                    cell_text = " ".join([
+                                        id2block[child_id]['Text']
+                                        for child_id in cell_block["Relationships"][0]['Ids']
+                                        if 'Text' in id2block[child_id]
+                                    ])
                                     row_idx = cell_block['RowIndex']
                                     col_idx = cell_block['ColumnIndex']
                                     max_row = max(max_row, row_idx)


### PR DESCRIPTION
Ignore table cell children with no text
For example on the document 1233376, one of the cell's children is of type `SELECTION_ELEMENT` that has no "text"

https://alanhealth.slack.com/archives/C041V4ECY5S/p1707900200813619
